### PR TITLE
add versioned image urls

### DIFF
--- a/SDMetaUI/Controllers/ImagesController.cs
+++ b/SDMetaUI/Controllers/ImagesController.cs
@@ -14,6 +14,8 @@ namespace SDMetaUI.Controllers
         {
             try
             {
+                EnableCaching(httpResponse);
+
                 string physicalPath = Base32Decode(path);
                 if (fileSystem.File.Exists(physicalPath))
                 {
@@ -43,6 +45,8 @@ namespace SDMetaUI.Controllers
         {
             try
             {
+                EnableCaching(httpResponse);
+
                 string physicalPath = Base32Decode(path);
                 if (fileSystem.File.Exists(physicalPath))
                 {
@@ -65,6 +69,11 @@ namespace SDMetaUI.Controllers
         {
             var base32EncodedBytes = Base32Encoding.ToBytes(base32EncodedData);
             return System.Text.Encoding.UTF8.GetString(base32EncodedBytes);
+        }
+
+        private static void EnableCaching(HttpResponse httpResponse)
+        {
+            httpResponse.Headers.CacheControl = "public, max-age=31536000, immutable";
         }
     }
 }

--- a/SDMetaUI/Controllers/ImagesController.cs
+++ b/SDMetaUI/Controllers/ImagesController.cs
@@ -14,11 +14,10 @@ namespace SDMetaUI.Controllers
         {
             try
             {
-                EnableCaching(httpResponse);
-
                 string physicalPath = Base32Decode(path);
                 if (fileSystem.File.Exists(physicalPath))
                 {
+                    EnableCaching(httpResponse);
                     var fileInfo = fileSystem.FileInfo.New(physicalPath);
                     var thumbPath = thumbnailService.GetOrGenerateThumbnail(fileInfo.FullName);
                     httpResponse.Headers.LastModified = fileInfo.LastWriteTimeUtc.ToString("R");
@@ -45,11 +44,10 @@ namespace SDMetaUI.Controllers
         {
             try
             {
-                EnableCaching(httpResponse);
-
                 string physicalPath = Base32Decode(path);
                 if (fileSystem.File.Exists(physicalPath))
                 {
+                    EnableCaching(httpResponse);
                     httpResponse.Headers.LastModified = fileSystem.FileInfo.New(physicalPath).LastWriteTimeUtc.ToString("R");
                     return Results.File(physicalPath, "image/png");
                 }

--- a/SDMetaUI/Models/ImageFileViewModel.cs
+++ b/SDMetaUI/Models/ImageFileViewModel.cs
@@ -1,28 +1,30 @@
 ﻿namespace SDMetaUI.Models
 {
-	public class ImageFileViewModel
-	{
-		private readonly Func<string, string> func;
+    public class ImageFileViewModel
+    {
+        private readonly Func<string, string> func;
+        private readonly string version;
 
-		public ImageFileViewModel(string fileName, string fullPromptHash, Func<string, string> func)
-		{
-			FileName = fileName;
-			FullPromptHash = fullPromptHash;
-			this.func = func;
-			this.EncodedFileName = new(() => Base32Encode(this.FileName));
-		}
-		public string FileName { get; }
-		public string ThumbnailUrl => $"/images/thumb/{EncodedFileName.Value}";
-		public string ImageUrl => $"/images/full/{EncodedFileName.Value}/{func(this.FileName)}";
-		public string FullPromptHash { get; }
-		public IList<ImageFileViewModel>? SubItems { get; set; }
+        public ImageFileViewModel(string fileName, string fullPromptHash, string version, Func<string, string> func)
+        {
+            FileName = fileName;
+            FullPromptHash = fullPromptHash;
+            this.version = version;
+            this.func = func;
+            this.EncodedFileName = new(() => Base32Encode(this.FileName));
+        }
+        public string FileName { get; }
+        public string ThumbnailUrl => $"/images/thumb/{EncodedFileName.Value}?v={version}";
+        public string ImageUrl => $"/images/full/{EncodedFileName.Value}/{func(this.FileName)}?v={version}";
+        public string FullPromptHash { get; }
+        public IList<ImageFileViewModel>? SubItems { get; set; }
 
-		private readonly Lazy<string> EncodedFileName; 
+        private readonly Lazy<string> EncodedFileName;
 
-		private static string Base32Encode(string plainText)
-		{
-			var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
-			return Base32Encoding.ToString(plainTextBytes);
-		}
-	}
+        private static string Base32Encode(string plainText)
+        {
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
+            return Base32Encoding.ToString(plainTextBytes);
+        }
+    }
 }

--- a/SDMetaUI/Models/ImageFileViewModelBuilder.cs
+++ b/SDMetaUI/Models/ImageFileViewModelBuilder.cs
@@ -3,11 +3,12 @@ using System.IO.Abstractions;
 
 namespace SDMetaUI.Models
 {
-	public class ImageFileViewModelBuilder(IFileSystem fileSystem)
-	{
-		public ImageFileViewModel BuildModel(ImageFileSummary p)
-		{
-			return new ImageFileViewModel(p.FileName, p.FullPromptHash ?? "", fileSystem.Path.GetFileName);
-		}
-	}
+    public class ImageFileViewModelBuilder(IFileSystem fileSystem)
+    {
+        public ImageFileViewModel BuildModel(ImageFileSummary p)
+        {
+            var lastWriteTicks = fileSystem.FileInfo.New(p.FileName).LastWriteTimeUtc.Ticks.ToString();
+            return new ImageFileViewModel(p.FileName, p.FullPromptHash ?? "", lastWriteTicks, fileSystem.Path.GetFileName);
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces improvements to image caching and cache busting in the application. It enables aggressive HTTP caching for image endpoints and adds a version query parameter to image URLs based on the file's last modification time, ensuring that clients always receive the latest image when it changes.

**Caching improvements:**

* Added the `EnableCaching` method to set HTTP response headers (`Cache-Control: public, max-age=31536000, immutable`) for both thumbnail and full image endpoints, allowing browsers to cache images for up to one year. [[1]](diffhunk://#diff-9be2c83c5a1fac44fb42a2f99faef3cf013b6b3e06992313dce418ddae3ca1ebR17-R18) [[2]](diffhunk://#diff-9be2c83c5a1fac44fb42a2f99faef3cf013b6b3e06992313dce418ddae3ca1ebR48-R49) [[3]](diffhunk://#diff-9be2c83c5a1fac44fb42a2f99faef3cf013b6b3e06992313dce418ddae3ca1ebR73-R77)

**Cache busting for image URLs:**

* Updated the `ImageFileViewModel` to include a `version` parameter (derived from the image file's last modification timestamp) in image URLs. This ensures that when an image changes, the URL changes as well, invalidating the browser cache.
* Modified the `ImageFileViewModelBuilder` to pass the file's last write time as the version parameter when constructing the view model.